### PR TITLE
Fixes for Timers

### DIFF
--- a/rclrs/src/clock.rs
+++ b/rclrs/src/clock.rs
@@ -66,21 +66,26 @@ impl Clock {
     }
 
     fn make(kind: ClockType) -> Self {
-        let mut rcl_clock;
+        let rcl_clock;
         unsafe {
             // SAFETY: Getting a default value is always safe.
-            rcl_clock = Self::init_generic_clock();
+            let allocator = rcutils_get_default_allocator();
+            rcl_clock = Arc::new(Mutex::new(rcl_clock_t {
+                type_: rcl_clock_type_t::RCL_CLOCK_UNINITIALIZED,
+                jump_callbacks: std::ptr::null_mut(),
+                num_jump_callbacks: 0,
+                get_now: None,
+                data: std::ptr::null_mut::<std::os::raw::c_void>(),
+                allocator,
+            }));
             let mut allocator = rcutils_get_default_allocator();
             // Function will return Err(_) only if there isn't enough memory to allocate a clock
             // object.
-            rcl_clock_init(kind.into(), &mut rcl_clock, &mut allocator)
+            rcl_clock_init(kind.into(), &mut *rcl_clock.lock().unwrap(), &mut allocator)
                 .ok()
                 .unwrap();
         }
-        Self {
-            kind,
-            rcl_clock: Arc::new(Mutex::new(rcl_clock)),
-        }
+        Self { kind, rcl_clock }
     }
 
     /// Returns the clock's `rcl_clock_t`.
@@ -104,22 +109,6 @@ impl Clock {
         Time {
             nsec: time_point,
             clock: Arc::downgrade(&self.rcl_clock),
-        }
-    }
-
-    /// Helper function to privately initialize a default clock, with the same behavior as
-    /// `rcl_init_generic_clock`. By defining a private function instead of implementing
-    /// `Default`,  we avoid exposing a public API to create an invalid clock.
-    // SAFETY: Getting a default value is always safe.
-    unsafe fn init_generic_clock() -> rcl_clock_t {
-        let allocator = rcutils_get_default_allocator();
-        rcl_clock_t {
-            type_: rcl_clock_type_t::RCL_CLOCK_UNINITIALIZED,
-            jump_callbacks: std::ptr::null_mut::<rcl_jump_callback_info_t>(),
-            num_jump_callbacks: 0,
-            get_now: None,
-            data: std::ptr::null_mut::<std::os::raw::c_void>(),
-            allocator,
         }
     }
 }

--- a/rclrs/src/error.rs
+++ b/rclrs/src/error.rs
@@ -53,7 +53,10 @@ impl Display for RclrsError {
                 )
             }
             RclrsError::NegativeDuration(duration) => {
-                write!(f, "A duration was negative when it should not have been: {duration:?}")
+                write!(
+                    f,
+                    "A duration was negative when it should not have been: {duration:?}"
+                )
             }
         }
     }

--- a/rclrs/src/error.rs
+++ b/rclrs/src/error.rs
@@ -32,6 +32,10 @@ pub enum RclrsError {
     },
     /// It was attempted to add a waitable to a wait set twice.
     AlreadyAddedToWaitSet,
+    /// A negative duration was obtained from rcl which should have been positive.
+    ///
+    /// The value represents nanoseconds.
+    NegativeDuration(i64),
 }
 
 impl Display for RclrsError {
@@ -47,6 +51,9 @@ impl Display for RclrsError {
                     f,
                     "Could not add entity to wait set because it was already added to a wait set"
                 )
+            }
+            RclrsError::NegativeDuration(duration) => {
+                write!(f, "A duration was negative when it should not have been: {duration:?}")
             }
         }
     }
@@ -80,6 +87,7 @@ impl Error for RclrsError {
             RclrsError::UnknownRclError { msg, .. } => msg.as_ref().map(|e| e as &dyn Error),
             RclrsError::StringContainsNul { err, .. } => Some(err).map(|e| e as &dyn Error),
             RclrsError::AlreadyAddedToWaitSet => None,
+            RclrsError::NegativeDuration(_) => None,
         }
     }
 }

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -13,11 +13,11 @@ use rosidl_runtime_rs::Message;
 
 pub use self::{builder::*, graph::*};
 use crate::{
-    rcl_bindings::*, Client, ClientBase, Clock, Context, ContextHandle, GuardCondition, LogParams,
-    Logger, ParameterBuilder, ParameterInterface, ParameterVariant, Parameters, Publisher,
-    QoSProfile, RclrsError, Service, ServiceBase, Subscription, SubscriptionBase,
-    SubscriptionCallback, TimeSource, Timer, IntoTimerOptions, AnyTimerCallback,
-    TimerCallRepeating, TimerCallOnce, ToLogParams, ENTITY_LIFECYCLE_MUTEX,
+    rcl_bindings::*, AnyTimerCallback, Client, ClientBase, Clock, Context, ContextHandle,
+    GuardCondition, IntoTimerOptions, LogParams, Logger, ParameterBuilder, ParameterInterface,
+    ParameterVariant, Parameters, Publisher, QoSProfile, RclrsError, Service, ServiceBase,
+    Subscription, SubscriptionBase, SubscriptionCallback, TimeSource, Timer, TimerCallOnce,
+    TimerCallRepeating, ToLogParams, ENTITY_LIFECYCLE_MUTEX,
 };
 
 // SAFETY: The functions accessing this type, including drop(), shouldn't care about the thread
@@ -636,10 +636,7 @@ mod tests {
             .namespace("test_create_timer")
             .build()?;
 
-        let _timer = node.create_timer_repeating(
-            Duration::from_millis(1),
-            || { }
-        )?;
+        let _timer = node.create_timer_repeating(Duration::from_millis(1), || {})?;
         assert_eq!(node.live_timers().len(), 1);
 
         Ok(())

--- a/rclrs/src/timer.rs
+++ b/rclrs/src/timer.rs
@@ -196,8 +196,9 @@ impl Timer {
         Ok(())
     }
 
-    /// Creates a new timer. Users should call [`Node::create_timer`] or
-    /// [`Node::create_timer_oneshot`].
+    /// Creates a new timer. Users should call one of [`Node::create_timer`],
+    /// [`Node::create_timer_repeating`], [`Node::create_timer_oneshot`], or
+    /// [`Node::create_timer_inert`].
     pub(crate) fn new(
         context: &ContextHandle,
         period: Duration,
@@ -286,7 +287,7 @@ impl Timer {
     }
 
     /// Updates the state of the rcl_timer to know that it has been called. This
-    /// should only be called by [`Self::execute`].
+    /// should only be called by [`Self::call`].
     ///
     /// The callback held by the rcl_timer is null because we store the callback
     /// in the [`Timer`] struct. This means there are no side-effects to this
@@ -530,7 +531,7 @@ mod tests {
         ));
 
         // The unwrap will panic if anything went wrong with the call
-        timer.rcl_call().unwrap();
+        timer.call().unwrap();
 
         // The unwrap will panic if the remaining time is negative
         timer.time_until_next_call().unwrap();

--- a/rclrs/src/timer.rs
+++ b/rclrs/src/timer.rs
@@ -1,10 +1,22 @@
-use crate::{clock::Clock, context::Context, error::RclrsError, rcl_bindings::*, to_rclrs_result};
+use crate::{
+    clock::Clock,
+    context::ContextHandle,
+    error::RclrsError,
+    rcl_bindings::*,
+    ToResult, log_error, ToLogParams, ENTITY_LIFECYCLE_MUTEX,
+};
 // TODO: fix me when the callback type is properly defined.
 // use std::fmt::Debug;
-use std::sync::{atomic::AtomicBool, Arc, Mutex};
+use std::{
+    sync::{atomic::AtomicBool, Arc, Mutex},
+    time::Duration,
+};
 
-/// Type alias for the `Timer` callback.
-pub type TimerCallback = Box<dyn Fn(i64) + Send + Sync>;
+mod timer_callback;
+pub use timer_callback::*;
+
+mod timer_options;
+pub use timer_options::*;
 
 /// Struct for executing periodic events.
 ///
@@ -23,29 +35,159 @@ pub type TimerCallback = Box<dyn Fn(i64) + Send + Sync>;
 pub struct Timer {
     pub(crate) rcl_timer: Arc<Mutex<rcl_timer_t>>,
     /// The callback function that runs when the timer is due.
-    callback: Option<TimerCallback>,
+    callback: Arc<Mutex<Option<AnyTimerCallback>>>,
+    /// We hold onto the Timer's clock for the whole lifespan of the Timer to
+    /// make sure the underlying `rcl_clock_t` remains valid.
+    clock: Clock,
     pub(crate) in_use_by_wait_set: Arc<AtomicBool>,
 }
 
 impl Timer {
-    /// Creates a new timer.
-    pub fn new(
-        clock: &Clock,
-        context: &Context,
-        period: i64,
-        callback: Option<TimerCallback>,
+    /// Gets the period of the timer
+    pub fn get_timer_period(&self) -> Result<Duration, RclrsError> {
+        let mut timer_period_ns = 0;
+        unsafe {
+            let rcl_timer = self.rcl_timer.lock().unwrap();
+            rcl_timer_get_period(&*rcl_timer, &mut timer_period_ns)
+        }.ok()?;
+
+        rcl_duration(timer_period_ns)
+    }
+
+    /// Cancels the timer, stopping the execution of the callback
+    pub fn cancel(&self) -> Result<(), RclrsError> {
+        let mut rcl_timer = self.rcl_timer.lock().unwrap();
+        let cancel_result = unsafe { rcl_timer_cancel(&mut *rcl_timer) }.ok()?;
+        Ok(cancel_result)
+    }
+
+    /// Checks whether the timer is canceled or not
+    pub fn is_canceled(&self) -> Result<bool, RclrsError> {
+        let mut is_canceled = false;
+        unsafe {
+            let rcl_timer = self.rcl_timer.lock().unwrap();
+            rcl_timer_is_canceled(&*rcl_timer, &mut is_canceled)
+        }.ok()?;
+        Ok(is_canceled)
+    }
+
+    /// Retrieves the time since the last call to the callback
+    pub fn time_since_last_call(&self) -> Result<Duration, RclrsError> {
+        let mut time_value_ns: i64 = 0;
+        unsafe {
+            let rcl_timer = self.rcl_timer.lock().unwrap();
+            rcl_timer_get_time_since_last_call(&*rcl_timer, &mut time_value_ns)
+        }.ok()?;
+
+        rcl_duration(time_value_ns)
+    }
+
+    /// Retrieves the time until the next call of the callback
+    pub fn time_until_next_call(&self) -> Result<Duration, RclrsError> {
+        let mut time_value_ns: i64 = 0;
+        unsafe {
+            let rcl_timer = self.rcl_timer.lock().unwrap();
+            rcl_timer_get_time_until_next_call(&*rcl_timer, &mut time_value_ns)
+        }.ok()?;
+
+        rcl_duration(time_value_ns)
+    }
+
+    /// Resets the timer.
+    pub fn reset(&self) -> Result<(), RclrsError> {
+        let mut rcl_timer = self.rcl_timer.lock().unwrap();
+        unsafe { rcl_timer_reset(&mut *rcl_timer) }.ok()
+    }
+
+    /// Checks if the timer is ready (not canceled)
+    pub fn is_ready(&self) -> Result<bool, RclrsError> {
+        let is_ready = unsafe {
+            let mut is_ready: bool = false;
+            let rcl_timer = self.rcl_timer.lock().unwrap();
+            rcl_timer_is_ready(&*rcl_timer, &mut is_ready).ok()?;
+            is_ready
+        };
+
+        Ok(is_ready)
+    }
+
+    /// Set a new callback for the timer. This will return whatever callback
+    /// was already present unless you are calling the function from inside of
+    /// the timer's callback, in which case you will receive [`None`].
+    ///
+    /// See also:
+    /// * [`Self::set_repeating`]
+    /// * [`Self::set_oneshot`]
+    /// * [`Self::remove_callback`].
+    pub fn set_callback(&self, callback: AnyTimerCallback) -> Option<AnyTimerCallback> {
+        self.callback.lock().unwrap().replace(callback)
+    }
+
+    /// Set a repeating callback for this timer.
+    ///
+    /// See also:
+    /// * [`Self::set_oneshot`]
+    /// * [`Self::remove_callback`]
+    pub fn set_repeating<Args>(&self, f: impl TimerCallRepeating<Args>) -> Option<AnyTimerCallback> {
+        self.set_callback(f.into_repeating_timer_callback())
+    }
+
+    /// Set a one-shot callback for the timer.
+    ///
+    /// The next time the timer is triggered, the callback will be set to
+    /// [`AnyTimerCallback::None`] after this callback is triggered. To keep the
+    /// timer useful, you can reset the Timer callback at any time, including
+    /// inside the one-shot callback itself.
+    ///
+    /// See also:
+    /// * [`Self::set_repeating`]
+    /// * [`Self::remove_callback`]
+    pub fn set_oneshot<Args>(&self, f: impl TimerCallOnce<Args>) -> Option<AnyTimerCallback> {
+        self.set_callback(f.into_oneshot_timer_callback())
+    }
+
+    /// Remove the callback from the timer.
+    ///
+    /// You can give the timer a new callback at any time by calling:
+    /// * [`Self::set_repeating`]
+    /// * [`Self::set_oneshot`]
+    pub fn remove_callback(&self) -> Option<AnyTimerCallback> {
+        self.set_callback(AnyTimerCallback::None)
+    }
+
+    /// This is triggerd when the Timer wakes up its wait set.
+    pub(crate) fn execute(&self) -> Result<(), RclrsError> {
+        if self.is_ready()? {
+            self.call()?;
+        }
+
+        Ok(())
+    }
+
+    /// Creates a new timer. Users should call [`Node::create_timer`] or
+    /// [`Node::create_timer_oneshot`].
+    pub(crate) fn new(
+        context: &ContextHandle,
+        period: Duration,
+        clock: Clock,
+        callback: AnyTimerCallback,
     ) -> Result<Timer, RclrsError> {
+        let period = period.as_nanos() as i64;
+        let mut rcl_clock = clock.get_rcl_clock().lock().unwrap();
+        let mut rcl_context = context.rcl_context.lock().unwrap();
+
+        // Callbacks will be handled at the rclrs layer.
+        let rcl_timer_callback: rcl_timer_callback_t = None;
+
         let mut rcl_timer;
-        let timer_init_result = unsafe {
+        unsafe {
             // SAFETY: Getting a default value is always safe.
             rcl_timer = rcl_get_zero_initialized_timer();
-            let mut rcl_clock = clock.get_rcl_clock().lock().unwrap();
             let allocator = rcutils_get_default_allocator();
-            let mut rcl_context = context.handle.rcl_context.lock().unwrap();
-            // Callbacks will be handled in the WaitSet.
-            let rcl_timer_callback: rcl_timer_callback_t = None;
-            // Function will return Err(_) only if there isn't enough memory to allocate a clock
-            // object.
+
+            let _lifecycle = ENTITY_LIFECYCLE_MUTEX.lock().unwrap();
+            // SAFETY: We lock the lifecycle mutex since rcl_timer_init is not
+            // thread-safe.
             rcl_timer_init(
                 &mut rcl_timer,
                 &mut *rcl_clock,
@@ -54,93 +196,74 @@ impl Timer {
                 rcl_timer_callback,
                 allocator,
             )
-        };
-        to_rclrs_result(timer_init_result).map(|_| Timer {
+        }.ok()?;
+
+        let timer = Timer {
             rcl_timer: Arc::new(Mutex::new(rcl_timer)),
-            callback,
+            callback: Arc::new(Mutex::new(Some(callback))),
+            clock: clock.clone(),
             in_use_by_wait_set: Arc::new(AtomicBool::new(false)),
-        })
-    }
-
-    /// Gets the period of the timer in nanoseconds
-    pub fn get_timer_period_ns(&self) -> Result<i64, RclrsError> {
-        let mut timer_period_ns = 0;
-        let get_period_result = unsafe {
-            let rcl_timer = self.rcl_timer.lock().unwrap();
-            rcl_timer_get_period(&*rcl_timer, &mut timer_period_ns)
         };
-        to_rclrs_result(get_period_result).map(|_| timer_period_ns)
+        Ok(timer)
     }
 
-    /// Cancels the timer, stopping the execution of the callback
-    pub fn cancel(&self) -> Result<(), RclrsError> {
-        let mut rcl_timer = self.rcl_timer.lock().unwrap();
-        let cancel_result = unsafe { rcl_timer_cancel(&mut *rcl_timer) };
-        to_rclrs_result(cancel_result)
-    }
-
-    /// Checks whether the timer is canceled or not
-    pub fn is_canceled(&self) -> Result<bool, RclrsError> {
-        let mut is_canceled = false;
-        let is_canceled_result = unsafe {
-            let rcl_timer = self.rcl_timer.lock().unwrap();
-            rcl_timer_is_canceled(&*rcl_timer, &mut is_canceled)
+    /// Force the timer to be called, even if it is not ready to be triggered yet.
+    /// We could consider making this public, but the behavior may confuse users.
+    fn call(&self) -> Result<(), RclrsError> {
+        let Some(callback) = self.callback.lock().unwrap().take() else {
+            log_error!(
+                "timer".once(),
+                "Timer is missing its callback information. This should not \
+                be possible, please report it to the maintainers of rclrs.",
+            );
+            return Ok(());
         };
-        to_rclrs_result(is_canceled_result).map(|_| is_canceled)
-    }
 
-    /// Retrieves the time since the last call to the callback
-    pub fn time_since_last_call(&self) -> Result<i64, RclrsError> {
-        let mut time_value_ns: i64 = 0;
-        let time_since_last_call_result = unsafe {
-            let rcl_timer = self.rcl_timer.lock().unwrap();
-            rcl_timer_get_time_since_last_call(&*rcl_timer, &mut time_value_ns)
-        };
-        to_rclrs_result(time_since_last_call_result).map(|_| time_value_ns)
-    }
-
-    /// Retrieves the time until the next call of the callback
-    pub fn time_until_next_call(&self) -> Result<i64, RclrsError> {
-        let mut time_value_ns: i64 = 0;
-        let time_until_next_call_result = unsafe {
-            let rcl_timer = self.rcl_timer.lock().unwrap();
-            rcl_timer_get_time_until_next_call(&*rcl_timer, &mut time_value_ns)
-        };
-        to_rclrs_result(time_until_next_call_result).map(|_| time_value_ns)
-    }
-
-    /// Resets the timer.
-    pub fn reset(&self) -> Result<(), RclrsError> {
-        let mut rcl_timer = self.rcl_timer.lock().unwrap();
-        to_rclrs_result(unsafe { rcl_timer_reset(&mut *rcl_timer) })
-    }
-
-    /// Executes the callback of the timer (this is triggered by the executor or the node directly)
-    pub fn call(&self) -> Result<(), RclrsError> {
-        let mut rcl_timer = self.rcl_timer.lock().unwrap();
-        to_rclrs_result(unsafe { rcl_timer_call(&mut *rcl_timer) })
-    }
-
-    /// Checks if the timer is ready (not canceled)
-    pub fn is_ready(&self) -> Result<bool, RclrsError> {
-        let (is_ready, is_ready_result) = unsafe {
-            let mut is_ready: bool = false;
-            let rcl_timer = self.rcl_timer.lock().unwrap();
-            let is_ready_result = rcl_timer_is_ready(&*rcl_timer, &mut is_ready);
-            (is_ready, is_ready_result)
-        };
-        to_rclrs_result(is_ready_result).map(|_| is_ready)
-    }
-
-    pub(crate) fn execute(&self) -> Result<(), RclrsError> {
-        if self.is_ready()? {
-            let time_since_last_call = self.time_since_last_call()?;
-            self.call()?;
-            if let Some(ref callback) = self.callback {
-                callback(time_since_last_call);
+        match callback {
+            AnyTimerCallback::Repeating(mut callback) => {
+                callback(self);
+                self.restore_callback(AnyTimerCallback::Repeating(callback));
+            }
+            AnyTimerCallback::OneShot(callback) => {
+                callback(self);
+                // We restore the callback as None because this was a
+                // one-shot which has been consumed.
+                self.restore_callback(AnyTimerCallback::None);
+            }
+            AnyTimerCallback::None => {
+                // Nothing to do here, just restore the callback.
+                self.restore_callback(AnyTimerCallback::None);
             }
         }
+
+        if let Err(err) = self.rcl_call() {
+            log_error!(
+                "timer",
+                "Unable to call timer: {err:?}",
+            );
+        }
+
         Ok(())
+    }
+
+    /// Updates the state of the rcl_timer to know that it has been called. This
+    /// should only be called by [`Self::execute`].
+    ///
+    /// The callback held by the rcl_timer is null because we store the callback
+    /// in the [`Timer`] struct. This means there are no side-effects to this
+    /// except to keep track of when the timer has been called.
+    fn rcl_call(&self) -> Result<(), RclrsError> {
+        let mut rcl_timer = self.rcl_timer.lock().unwrap();
+        unsafe { rcl_timer_call(&mut *rcl_timer) }.ok()
+    }
+
+    /// Used by [`Timer::execute`] to restore the state of the callback if and
+    /// only if the user has not already set a new callback.
+    fn restore_callback(&self, callback: AnyTimerCallback) {
+        let mut self_callback = self.callback.lock().unwrap();
+        if self_callback.is_none() {
+            *self_callback = Some(callback);
+        }
     }
 }
 
@@ -148,10 +271,7 @@ impl Timer {
 impl Drop for rcl_timer_t {
     fn drop(&mut self) {
         // SAFETY: No preconditions for this function
-        let rc = unsafe { rcl_timer_fini(&mut *self) };
-        if let Err(e) = to_rclrs_result(rc) {
-            panic!("Unable to release Timer. {:?}", e)
-        }
+        unsafe { rcl_timer_fini(&mut *self) };
     }
 }
 
@@ -161,18 +281,22 @@ impl PartialEq for Timer {
     }
 }
 
+fn rcl_duration(duration_value_ns: i64) -> Result<Duration, RclrsError> {
+    if duration_value_ns < 0 {
+        Err(RclrsError::NegativeDuration(duration_value_ns))
+    } else {
+        Ok(Duration::from_nanos(duration_value_ns as u64))
+    }
+}
+
 // SAFETY: The functions accessing this type, including drop(), shouldn't care about the thread
 // they are running in. Therefore, this type can be safely sent to another thread.
 unsafe impl Send for rcl_timer_t {}
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::{thread, time};
-
-    fn create_dummy_callback() -> Option<TimerCallback> {
-        Some(Box::new(move |_| {}))
-    }
+    use crate::*;
+    use std::{thread, time, sync::atomic::{AtomicBool, Ordering}};
 
     #[test]
     fn traits() {
@@ -184,23 +308,28 @@ mod tests {
 
     #[test]
     fn test_new_with_system_clock() {
-        let clock = Clock::system();
         let context = Context::new(vec![]).unwrap();
-        let period: i64 = 1e6 as i64; // 1 milliseconds.
-        let dut = Timer::new(&clock, &context, period, create_dummy_callback());
-        assert!(dut.is_ok());
+        let result = Timer::new(
+            &context.handle,
+            Duration::from_millis(1),
+            Clock::system(),
+            (|| { }).into_repeating_timer_callback(),
+        );
+        assert!(result.is_ok());
     }
 
     #[test]
     fn test_new_with_steady_clock() {
-        let clock = Clock::steady();
         let context = Context::new(vec![]).unwrap();
-        let period: i64 = 1e6 as i64; // 1 milliseconds.
-        let dut = Timer::new(&clock, &context, period, create_dummy_callback());
-        assert!(dut.is_ok());
+        let result = Timer::new(
+            &context.handle,
+            Duration::from_millis(1),
+            Clock::steady(),
+            (|| { }).into_repeating_timer_callback(),
+        );
+        assert!(result.is_ok());
     }
 
-    #[ignore = "SIGSEGV when creating the timer with Clock::with_source()."]
     #[test]
     fn test_new_with_source_clock() {
         let (clock, source) = Clock::with_source();
@@ -208,191 +337,237 @@ mod tests {
         assert!(clock.now().nsec == 0);
         let set_time = 1234i64;
         source.set_ros_time_override(set_time);
-        // Ros time is set, should return the value that was set
+
+        // ROS time is set, should return the value that was set
         assert_eq!(clock.now().nsec, set_time);
+
         let context = Context::new(vec![]).unwrap();
-        let period: i64 = 1e6 as i64; // 1 milliseconds..
-        let dut = Timer::new(&clock, &context, period, create_dummy_callback());
-        assert!(dut.is_ok());
+        let result = Timer::new(
+            &context.handle,
+            Duration::from_millis(1),
+            clock,
+            (|| { }).into_repeating_timer_callback(),
+        );
+        assert!(result.is_ok());
     }
 
     #[test]
     fn test_get_period() {
-        let clock = Clock::steady();
+        let period = Duration::from_millis(1);
         let context = Context::new(vec![]).unwrap();
-        let period: i64 = 1e6 as i64; // 1 milliseconds.
-        let dut = Timer::new(&clock, &context, period, create_dummy_callback());
-        assert!(dut.is_ok());
-        let dut = dut.unwrap();
-        let period_result = dut.get_timer_period_ns();
-        assert!(period_result.is_ok());
-        let period_result = period_result.unwrap();
-        assert_eq!(period_result, 1e6 as i64);
+
+        let result = Timer::new(
+            &context.handle,
+            period,
+            Clock::steady(),
+            (|| { }).into_repeating_timer_callback(),
+        );
+
+        let timer = result.unwrap();
+        let timer_period = timer.get_timer_period().unwrap();
+        assert_eq!(timer_period, period);
     }
 
     #[test]
     fn test_cancel() {
-        let clock = Clock::steady();
         let context = Context::new(vec![]).unwrap();
-        let period: i64 = 1e6 as i64; // 1 milliseconds.
-        let dut = Timer::new(&clock, &context, period, create_dummy_callback());
-        assert!(dut.is_ok());
-        let dut = dut.unwrap();
-        assert!(dut.is_canceled().is_ok());
-        assert!(!dut.is_canceled().unwrap());
-        let cancel_result = dut.cancel();
-        assert!(cancel_result.is_ok());
-        assert!(dut.is_canceled().is_ok());
-        assert!(dut.is_canceled().unwrap());
+
+        let result = Timer::new(
+            &context.handle,
+            Duration::from_millis(1),
+            Clock::steady(),
+            (|| { }).into_repeating_timer_callback(),
+        );
+
+        let timer = result.unwrap();
+        assert!(!timer.is_canceled().unwrap());
+        timer.cancel().unwrap();
+        assert!(timer.is_canceled().unwrap());
     }
 
     #[test]
     fn test_time_since_last_call_before_first_event() {
-        let clock = Clock::steady();
         let context = Context::new(vec![]).unwrap();
-        let period_ns: i64 = 2e6 as i64; // 2 milliseconds.
-        let sleep_period_ms = time::Duration::from_millis(1);
-        let dut = Timer::new(&clock, &context, period_ns, create_dummy_callback());
-        assert!(dut.is_ok());
-        let dut = dut.unwrap();
-        thread::sleep(sleep_period_ms);
-        let time_since_last_call = dut.time_since_last_call();
-        assert!(time_since_last_call.is_ok());
-        let time_since_last_call = time_since_last_call.unwrap();
+
+        let result = Timer::new(
+            &context.handle,
+            Duration::from_millis(2),
+            Clock::steady(),
+            (|| { }).into_repeating_timer_callback(),
+        );
+        let timer = result.unwrap();
+
+        let sleep_period = time::Duration::from_millis(1);
+        thread::sleep(sleep_period);
+
+        let time_since_last_call = timer.time_since_last_call().unwrap();
         assert!(
-            time_since_last_call > 9e5 as i64,
-            "time_since_last_call: {}",
-            time_since_last_call
+            time_since_last_call >= sleep_period,
+            "time_since_last_call: {:?} vs sleep period: {:?}",
+            time_since_last_call,
+            sleep_period,
         );
     }
 
     #[test]
     fn test_time_until_next_call_before_first_event() {
-        let clock = Clock::steady();
         let context = Context::new(vec![]).unwrap();
-        let period_ns: i64 = 2e6 as i64; // 2 milliseconds.
-        let dut = Timer::new(&clock, &context, period_ns, create_dummy_callback());
-        assert!(dut.is_ok());
-        let dut = dut.unwrap();
-        let time_until_next_call = dut.time_until_next_call();
-        assert!(time_until_next_call.is_ok());
-        let time_until_next_call = time_until_next_call.unwrap();
+        let period = Duration::from_millis(2);
+
+        let result = Timer::new(
+            &context.handle,
+            period,
+            Clock::steady(),
+            (|| { }).into_repeating_timer_callback(),
+        );
+        let timer = result.unwrap();
+
+        let time_until_next_call = timer.time_until_next_call().unwrap();
         assert!(
-            time_until_next_call < period_ns,
-            "time_until_next_call: {}",
-            time_until_next_call
+            time_until_next_call <= period,
+            "time_until_next_call: {:?} vs period: {:?}",
+            time_until_next_call,
+            period,
         );
     }
 
     #[test]
     fn test_reset() {
-        let tolerance = 20e4 as i64;
-        let clock = Clock::steady();
         let context = Context::new(vec![]).unwrap();
-        let period_ns: i64 = 2e6 as i64; // 2 milliseconds.
-        let dut = Timer::new(&clock, &context, period_ns, create_dummy_callback()).unwrap();
-        let elapsed = period_ns - dut.time_until_next_call().unwrap();
-        assert!(elapsed < tolerance, "elapsed before reset: {}", elapsed);
-        thread::sleep(time::Duration::from_millis(1));
-        assert!(dut.reset().is_ok());
-        let elapsed = period_ns - dut.time_until_next_call().unwrap();
-        assert!(elapsed < tolerance, "elapsed after reset: {}", elapsed);
+        let period = Duration::from_millis(2);
+        let timer = Timer::new(
+            &context.handle,
+            period,
+            Clock::steady(),
+            (|| { }).into_repeating_timer_callback(),
+        ).unwrap();
+
+        // The unwrap will panic if the remaining time is negative
+        timer.time_until_next_call().unwrap();
+
+        // Sleep until we're past the timer period
+        thread::sleep(Duration::from_millis(3));
+
+        // Now the time until next call should give an error
+        assert!(matches!(timer.time_until_next_call(), Err(RclrsError::NegativeDuration(_))));
+
+        // Reset the timer so its interval begins again
+        assert!(timer.reset().is_ok());
+
+        // The unwrap will panic if the remaining time is negative
+        timer.time_until_next_call().unwrap();
     }
 
     #[test]
     fn test_call() {
-        let tolerance = 20e4 as i64;
-        let clock = Clock::steady();
         let context = Context::new(vec![]).unwrap();
-        let period_ns: i64 = 1e6 as i64; // 1 millisecond.
-        let dut = Timer::new(&clock, &context, period_ns, create_dummy_callback()).unwrap();
-        let elapsed = period_ns - dut.time_until_next_call().unwrap();
-        assert!(elapsed < tolerance, "elapsed before reset: {}", elapsed);
+        let timer = Timer::new(
+            &context.handle,
+            Duration::from_millis(1),
+            Clock::steady(),
+            (|| { }).into_repeating_timer_callback(),
+        ).unwrap();
+
+        // The unwrap will panic if the remaining time is negative
+        timer.time_until_next_call().unwrap();
+
+        // Sleep until we're past the timer period
         thread::sleep(time::Duration::from_micros(1500));
-        let elapsed = period_ns - dut.time_until_next_call().unwrap();
-        assert!(
-            elapsed > 1500000i64,
-            "time_until_next_call before call: {}",
-            elapsed
-        );
-        assert!(dut.call().is_ok());
-        let elapsed = dut.time_until_next_call().unwrap();
-        assert!(
-            elapsed < 500000i64,
-            "time_until_next_call after call: {}",
-            elapsed
-        );
+
+        // Now the time until the next call should give an error
+        assert!(matches!(timer.time_until_next_call(), Err(RclrsError::NegativeDuration(_))));
+
+        // The unwrap will panic if anything went wrong with the call
+        timer.rcl_call().unwrap();
+
+        // The unwrap will panic if the remaining time is negative
+        timer.time_until_next_call().unwrap();
     }
 
     #[test]
     fn test_is_ready() {
-        let clock = Clock::steady();
         let context = Context::new(vec![]).unwrap();
-        let period_ns: i64 = 1e6 as i64; // 1 millisecond.
-        let dut = Timer::new(&clock, &context, period_ns, create_dummy_callback()).unwrap();
-        let is_ready = dut.is_ready();
-        assert!(is_ready.is_ok());
-        assert!(!is_ready.unwrap());
-        thread::sleep(time::Duration::from_micros(1100));
-        let is_ready = dut.is_ready();
-        assert!(is_ready.is_ok());
-        assert!(is_ready.unwrap());
+        let timer = Timer::new(
+            &context.handle,
+            Duration::from_millis(1),
+            Clock::steady(),
+            (|| { }).into_repeating_timer_callback(),
+        ).unwrap();
+
+        assert!(!timer.is_ready().unwrap());
+
+        // Sleep until the period has elapsed
+        thread::sleep(Duration::from_micros(1100));
+
+        assert!(timer.is_ready().unwrap());
     }
 
     #[test]
     fn test_callback() {
         let clock = Clock::steady();
+        let initial_time = clock.now();
         let context = Context::new(vec![]).unwrap();
-        let period_ns: i64 = 1e6 as i64; // 1 millisecond.
-        let foo = Arc::new(Mutex::new(0i64));
-        let foo_callback = foo.clone();
-        let dut = Timer::new(
-            &clock,
-            &context,
-            period_ns,
-            Some(Box::new(move |x| *foo_callback.lock().unwrap() = x)),
+        let executed = Arc::new(AtomicBool::new(false));
+
+        let timer = Timer::new(
+            &context.handle,
+            Duration::from_millis(1),
+            clock,
+            create_timer_callback_for_testing(initial_time, Arc::clone(&executed)),
         )
         .unwrap();
-        dut.callback.unwrap()(123);
-        assert_eq!(*foo.lock().unwrap(), 123);
+
+        timer.call().unwrap();
+        assert!(executed.load(Ordering::Acquire));
     }
 
     #[test]
     fn test_execute_when_is_not_ready() {
         let clock = Clock::steady();
+        let initial_time = clock.now();
         let context = Context::new(vec![]).unwrap();
-        let period_ns: i64 = 1e6 as i64; // 1 millisecond.
-        let foo = Arc::new(Mutex::new(0i64));
-        let foo_callback = foo.clone();
-        let dut = Timer::new(
-            &clock,
-            &context,
-            period_ns,
-            Some(Box::new(move |x| *foo_callback.lock().unwrap() = x)),
+        let executed = Arc::new(AtomicBool::new(false));
+
+        let timer = Timer::new(
+            &context.handle,
+            Duration::from_millis(1),
+            clock,
+            create_timer_callback_for_testing(initial_time, Arc::clone(&executed)),
         )
         .unwrap();
-        assert!(dut.execute().is_ok());
-        assert_eq!(*foo.lock().unwrap(), 0i64);
+
+        timer.execute().unwrap();
+        assert!(!executed.load(Ordering::Acquire));
     }
 
     #[test]
     fn test_execute_when_is_ready() {
         let clock = Clock::steady();
+        let initial_time = clock.now();
         let context = Context::new(vec![]).unwrap();
-        let period_ns: i64 = 1e6 as i64; // 1 millisecond.
-        let foo = Arc::new(Mutex::new(0i64));
-        let foo_callback = foo.clone();
-        let dut = Timer::new(
-            &clock,
-            &context,
-            period_ns,
-            Some(Box::new(move |x| *foo_callback.lock().unwrap() = x)),
+        let executed = Arc::new(AtomicBool::new(false));
+
+        let timer = Timer::new(
+            &context.handle,
+            Duration::from_millis(1),
+            clock,
+            create_timer_callback_for_testing(initial_time, Arc::clone(&executed)),
         )
         .unwrap();
-        thread::sleep(time::Duration::from_micros(1500));
-        assert!(dut.execute().is_ok());
-        let x = *foo.lock().unwrap();
-        assert!(x > 1500000i64);
-        assert!(x < 1600000i64);
+
+        thread::sleep(time::Duration::from_millis(2));
+
+        timer.execute().unwrap();
+        assert!(executed.load(Ordering::Acquire));
+    }
+
+    fn create_timer_callback_for_testing(
+        initial_time: Time,
+        executed: Arc<AtomicBool>,
+    ) -> AnyTimerCallback {
+        (move |t: Time| {
+            assert!(t.compare_with(&initial_time, |t, initial| t >= initial).unwrap());
+            executed.store(true, Ordering::Release);
+        }).into_oneshot_timer_callback()
     }
 }

--- a/rclrs/src/timer.rs
+++ b/rclrs/src/timer.rs
@@ -147,7 +147,7 @@ impl Timer {
     /// See also:
     /// * [`Self::set_repeating`]
     /// * [`Self::set_oneshot`]
-    /// * [`Self::remove_callback`].
+    /// * [`Self::set_inert`].
     pub fn set_callback(&self, callback: AnyTimerCallback) -> Option<AnyTimerCallback> {
         self.callback.lock().unwrap().replace(callback)
     }
@@ -156,7 +156,7 @@ impl Timer {
     ///
     /// See also:
     /// * [`Self::set_oneshot`]
-    /// * [`Self::remove_callback`]
+    /// * [`Self::set_inert`]
     pub fn set_repeating<Args>(
         &self,
         f: impl TimerCallRepeating<Args>,
@@ -173,17 +173,21 @@ impl Timer {
     ///
     /// See also:
     /// * [`Self::set_repeating`]
-    /// * [`Self::remove_callback`]
+    /// * [`Self::set_inert`]
     pub fn set_oneshot<Args>(&self, f: impl TimerCallOnce<Args>) -> Option<AnyTimerCallback> {
         self.set_callback(f.into_oneshot_timer_callback())
     }
 
     /// Remove the callback from the timer.
     ///
+    /// This does not cancel the timer; it will continue to wake up and be
+    /// triggered at its regular period. However, nothing will happen when the
+    /// timer is triggered until you give a new callback to the timer.
+    ///
     /// You can give the timer a new callback at any time by calling:
     /// * [`Self::set_repeating`]
     /// * [`Self::set_oneshot`]
-    pub fn remove_callback(&self) -> Option<AnyTimerCallback> {
+    pub fn set_inert(&self) -> Option<AnyTimerCallback> {
         self.set_callback(AnyTimerCallback::None)
     }
 

--- a/rclrs/src/timer/timer_callback.rs
+++ b/rclrs/src/timer/timer_callback.rs
@@ -17,6 +17,7 @@ pub enum AnyTimerCallback {
 /// callbacks can take the current [`Time`] as an argument, or [`Time`], or take
 /// no argument at all.
 pub trait TimerCallRepeating<Args>: Send + 'static {
+    /// Convert a suitable object into a repeating timer callback
     fn into_repeating_timer_callback(self) -> AnyTimerCallback;
 }
 
@@ -42,6 +43,7 @@ where
 /// callbacks can take the current [`Time`] as an argument, or [`Time`], or take
 /// no argument at all.
 pub trait TimerCallOnce<Args>: Send + 'static {
+    /// Convert a suitable object into a one-shot timer callback
     fn into_oneshot_timer_callback(self) -> AnyTimerCallback;
 }
 

--- a/rclrs/src/timer/timer_callback.rs
+++ b/rclrs/src/timer/timer_callback.rs
@@ -68,6 +68,6 @@ where
     Func: FnOnce(Time) + Send + 'static,
 {
     fn into_oneshot_timer_callback(self) -> AnyTimerCallback {
-        AnyTimerCallback::OneShot(Box::new(move |t| self(t.clock.now())))
+        AnyTimerCallback::OneShot(Box::new(move |t| self(t.handle.clock.now())))
     }
 }

--- a/rclrs/src/timer/timer_callback.rs
+++ b/rclrs/src/timer/timer_callback.rs
@@ -1,0 +1,73 @@
+use crate::{Time, Timer};
+
+/// A callback that can be triggered when a timer elapses.
+pub enum AnyTimerCallback {
+    /// This callback will be triggered repeatedly, each time the period of the
+    /// timer elapses.
+    Repeating(Box<dyn FnMut(&Timer) + Send>),
+    /// This callback will be triggered exactly once, the first time the period
+    /// of the timer elapses.
+    OneShot(Box<dyn FnOnce(&Timer) + Send>),
+    /// Do nothing when the timer elapses. This can be replaced later so that
+    /// the timer does something.
+    None,
+}
+
+/// This trait is used to create timer callbacks for repeating timers. Incoming
+/// callbacks can take the current [`Time`] as an argument, or [`Time`], or take
+/// no argument at all.
+pub trait TimerCallRepeating<Args>: Send + 'static {
+    fn into_repeating_timer_callback(self) -> AnyTimerCallback;
+}
+
+impl<Func> TimerCallRepeating<()> for Func
+where
+    Func: FnMut() + Send + 'static,
+{
+    fn into_repeating_timer_callback(mut self) -> AnyTimerCallback {
+        AnyTimerCallback::Repeating(Box::new(move |_| self()))
+    }
+}
+
+impl<Func> TimerCallRepeating<Timer> for Func
+where
+    Func: FnMut(&Timer) + Send + 'static,
+{
+    fn into_repeating_timer_callback(mut self) -> AnyTimerCallback {
+        AnyTimerCallback::Repeating(Box::new(move |t| self(t)))
+    }
+}
+
+/// This trait is used to create timer callbacks for one-shot timers. Incoming
+/// callbacks can take the current [`Time`] as an argument, or [`Time`], or take
+/// no argument at all.
+pub trait TimerCallOnce<Args>: Send + 'static {
+    fn into_oneshot_timer_callback(self) -> AnyTimerCallback;
+}
+
+impl<Func> TimerCallOnce<()> for Func
+where
+    Func: FnOnce() + Send + 'static,
+{
+    fn into_oneshot_timer_callback(self) -> AnyTimerCallback {
+        AnyTimerCallback::OneShot(Box::new(move |_| self()))
+    }
+}
+
+impl<Func> TimerCallOnce<Timer> for Func
+where
+    Func: FnOnce(&Timer) + Send + 'static,
+{
+    fn into_oneshot_timer_callback(self) -> AnyTimerCallback {
+        AnyTimerCallback::OneShot(Box::new(move |t| self(t)))
+    }
+}
+
+impl<Func> TimerCallOnce<Time> for Func
+where
+    Func: FnOnce(Time) + Send + 'static,
+{
+    fn into_oneshot_timer_callback(self) -> AnyTimerCallback {
+        AnyTimerCallback::OneShot(Box::new(move |t| self(t.clock.now())))
+    }
+}

--- a/rclrs/src/timer/timer_options.rs
+++ b/rclrs/src/timer/timer_options.rs
@@ -1,0 +1,93 @@
+use std::time::Duration;
+
+use crate::{Clock, Node};
+
+/// Options for creating a [`Timer`][crate::Timer].
+///
+/// The trait [`IntoTimerOptions`] can implicitly convert a single [`Duration`]
+/// into `TimerOptions`.
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct TimerOptions<'a> {
+    pub period: Duration,
+    pub clock: TimerClock<'a>,
+}
+
+impl TimerOptions<'_> {
+    pub fn new(period: Duration) -> Self {
+        Self {
+            period,
+            clock: TimerClock::default(),
+        }
+    }
+}
+
+pub trait IntoTimerOptions<'a>: Sized {
+    fn into_timer_options(self) -> TimerOptions<'a>;
+
+    /// Use [`std::time::Instant`] for the timer. This the default so you
+    /// shouldn't generally have to call this.
+    fn steady_time(self) -> TimerOptions<'a> {
+        let mut options = self.into_timer_options();
+        options.clock = TimerClock::SteadyTime;
+        options
+    }
+
+    /// Use [`std::time::SystemTime`] for the timer
+    fn system_time(self) -> TimerOptions<'a> {
+        let mut options = self.into_timer_options();
+        options.clock = TimerClock::SystemTime;
+        options
+    }
+
+    /// Use the node clock for the timer
+    fn node_time(self) -> TimerOptions<'a> {
+        let mut options = self.into_timer_options();
+        options.clock = TimerClock::NodeTime;
+        options
+    }
+
+    /// Use a specific clock for the
+    fn clock(self, clock: &'a Clock) -> TimerOptions<'a> {
+        let mut options = self.into_timer_options();
+        options.clock = TimerClock::Clock(clock);
+        options
+    }
+}
+
+/// This parameter can specify a type of clock for a timer to use
+#[derive(Debug, Default, Clone, Copy)]
+pub enum TimerClock<'a> {
+    /// Use [`std::time::Instant`] for tracking time
+    #[default]
+    SteadyTime,
+    /// Use [`std::time::SystemTime`] for tracking time
+    SystemTime,
+    /// Use the parent node's clock for tracking time
+    NodeTime,
+    /// Use a specific clock for tracking time
+    Clock(&'a Clock),
+}
+
+impl TimerClock<'_> {
+    pub(crate) fn as_clock(&self, node: &Node) -> Clock {
+        match self {
+            TimerClock::SteadyTime => Clock::steady(),
+            TimerClock::SystemTime => Clock::system(),
+            TimerClock::NodeTime => node.get_clock(),
+            TimerClock::Clock(clock) => (*clock).clone(),
+        }
+    }
+}
+
+impl<'a> IntoTimerOptions<'a> for TimerOptions<'a> {
+    fn into_timer_options(self) -> TimerOptions<'a> {
+        self
+    }
+}
+
+impl<'a> IntoTimerOptions<'a> for Duration {
+    fn into_timer_options(self) -> TimerOptions<'a> {
+        TimerOptions::new(self)
+    }
+}

--- a/rclrs/src/timer/timer_options.rs
+++ b/rclrs/src/timer/timer_options.rs
@@ -9,11 +9,15 @@ use crate::{Clock, Node};
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub struct TimerOptions<'a> {
+    /// The period of the timer's interval
     pub period: Duration,
+    /// The clock that the timer will reference for its intervals
     pub clock: TimerClock<'a>,
 }
 
 impl TimerOptions<'_> {
+    /// Make a new timer with a certain interval period, with all other options
+    /// as default.
     pub fn new(period: Duration) -> Self {
         Self {
             period,
@@ -22,7 +26,10 @@ impl TimerOptions<'_> {
     }
 }
 
+/// Trait to implicitly convert a suitable object into [`TimerOptions`].
 pub trait IntoTimerOptions<'a>: Sized {
+    /// Convert a suitable object into [`TimerOptions`]. This can be used on
+    /// [`Duration`] or [`TimerOptions`] itself.
     fn into_timer_options(self) -> TimerOptions<'a>;
 
     /// Use [`std::time::Instant`] for the timer. This the default so you

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -465,8 +465,7 @@ impl WaitSet {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::clock::Clock;
-    use crate::timer::*;
+    use crate::{clock::Clock, timer::*};
 
     #[test]
     fn traits() {
@@ -499,7 +498,7 @@ mod tests {
             &context.handle,
             Duration::from_millis(1),
             Clock::steady(),
-            (|| { }).into_repeating_timer_callback(),
+            (|| {}).into_repeating_timer_callback(),
         )?);
 
         let mut wait_set = WaitSet::new(0, 0, 1, 0, 0, 0, &context)?;
@@ -518,7 +517,7 @@ mod tests {
             &context.handle,
             Duration::from_millis(1),
             Clock::steady(),
-            (|| { }).into_repeating_timer_callback(),
+            (|| {}).into_repeating_timer_callback(),
         )?);
 
         let mut wait_set = WaitSet::new(0, 0, 1, 0, 0, 0, &context)?;

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -340,7 +340,7 @@ impl WaitSet {
             // Passing in a null pointer for the third argument is explicitly allowed.
             rcl_wait_set_add_timer(
                 &mut self.handle.rcl_wait_set,
-                &*timer.rcl_timer.lock().unwrap() as *const _,
+                &*timer.handle.rcl_timer.lock().unwrap() as *const _,
                 core::ptr::null_mut(),
             )
         }

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -466,7 +466,7 @@ impl WaitSet {
 mod tests {
     use super::*;
     use crate::clock::Clock;
-    use crate::timer::TimerCallback;
+    use crate::timer::*;
 
     #[test]
     fn traits() {
@@ -495,10 +495,12 @@ mod tests {
     #[test]
     fn timer_in_wait_not_set_readies() -> Result<(), RclrsError> {
         let context = Context::new([])?;
-        let clock = Clock::steady();
-        let period: i64 = 1e6 as i64; // 1 millisecond.
-        let callback: Option<TimerCallback> = Some(Box::new(move |_| {}));
-        let timer = Arc::new(Timer::new(&clock, &context, period, callback)?);
+        let timer = Arc::new(Timer::new(
+            &context.handle,
+            Duration::from_millis(1),
+            Clock::steady(),
+            (|| { }).into_repeating_timer_callback(),
+        )?);
 
         let mut wait_set = WaitSet::new(0, 0, 1, 0, 0, 0, &context)?;
         wait_set.add_timer(timer.clone())?;
@@ -512,10 +514,12 @@ mod tests {
     #[test]
     fn timer_in_wait_set_readies() -> Result<(), RclrsError> {
         let context = Context::new([])?;
-        let clock = Clock::steady();
-        let period: i64 = 1e6 as i64; // 1 millisecond.
-        let callback: Option<TimerCallback> = Some(Box::new(move |_| {}));
-        let timer = Arc::new(Timer::new(&clock, &context, period, callback)?);
+        let timer = Arc::new(Timer::new(
+            &context.handle,
+            Duration::from_millis(1),
+            Clock::steady(),
+            (|| { }).into_repeating_timer_callback(),
+        )?);
 
         let mut wait_set = WaitSet::new(0, 0, 1, 0, 0, 0, &context)?;
         wait_set.add_timer(timer.clone())?;


### PR DESCRIPTION
Thanks for kicking off the effort on `Timers` for rclrs with https://github.com/ros2-rust/ros2_rust/pull/440

Rather than write out a huge amount of feedback and leave it to you to interpret and implement it, I went ahead and cranked out a series of fixes that I recommend for your PR. I'll explain the various changes in a series of sections.

## Fixing object lifecycles

The `test_new_with_source_clock` test was having a segmentation fault in your original PR. I didn't identify the specific cause of this, but the overarching issue was that the lifecycles of `rcl_timer_t` and possibly `rcl_clock_t` were not being managed in a way that's compatible with `rcl`.

This PR changes both of those objects to use in-place initialization. That means we first create the `Arc<Mutex<T>>` that will hold the data structure (zero-initializing it to start), and then we call `rcl_[...]_init` on the object while the mutex is locked. This ensures that the address of the rcl object is never changed. Sometimes `rcl` is sensitive to the address of its objects moving, other times it's not, but it never hurts to take precautions and keep the addresses fixed throughout the lifetimes of the objects.

Secondly this PR introduces `TimerHandle` which guarantees that the `rcl_clock_t` being used by the `rcl_timer_t` cannot be dropped prematurely. In this new structure, `rcl_timer_fini` is only called when `TimerHandle` is dropped, ensuring that `rcl_clock_fini` cannot be called until afterwards.

## Streamlining API

In the original PR there were some superfluous arguments being passed into `create_timer`. The `Context` is already known by the `Node` so there's no reason for the user to pass that in. We can usually assume that the user will want a steady clock for their timer, so we shouldn't make it mandatory for them to pass in a clock.

In this PR we change the `create_timer` API to use `TimerOptions` to start off the user with a sensible set of default options, and `IntoTimerOptions` to conveniently build `TimerOptions` off of a `Duration`. This follows the same `_Options` pattern that was introduced in https://github.com/ros2-rust/ros2_rust/pull/422 and which will be applied to all create functions with https://github.com/ros2-rust/ros2_rust/pull/429.

## One-shot callbacks

A widely desired feature which hasn't made it into rclcpp yet is one-shot timers. The ability to define a one-shot timer is especially important for `rclrs` since Rust draws a very important categorical difference between `FnMut` and `FnOnce`. If we do not have built-in support for one-shot timers then users can never use `FnOnce` with their timers.

I've generalized the definition of timer callbacks to also support one-shot timers (see `AnyTimerCallback`) and added APIs to help users with creating repeating timers and one-shot timers. Users can also change the callback of a timer whenever they want, as long as they have access to the `&Timer`. This means after a one-shot callback has been triggered, the user can pass a new one-shot callback into the same timer, and that new callback will be called the next time the Timer is triggered. In fact the current one-shot callback itself can reload the timer with a new one-shot callback. Users can also switch between repeating, one-shot, or removed callback whenever they want.

## Callback flexibility

In the original PR users are expected to pass in a `Box<dyn Fn(i64) + ...>` as a callback, but most users will find it inconvenient to box their callback before providing it. They are also likely to be confused about what the `i64` means.

In this PR we introduce `trait TimerCallRepeatedly` and `trait TimerCallOnce` which allow users to directly pass in an `FnMut(_)` and `FnOnce(_)` for repeated and one-shot timers respectively. This is similar to [`SubscriptionCallback`](https://github.com/ros2-rust/ros2_rust/blob/3eba2b03e9730739721c10e9efd26034e021ea4b/rclrs/src/subscription/callback.rs#L9) which is used to make the subscription API very flexible.

We support three different choices of arguments for these callbacks:
* `&Timer`: The callback will receive a borrow of the timer that it belongs to. The user can call any function on the timer, including `Time::set_callback` to change the callback of the Timer and `Timer::last_elapsed` to check how much time elapsed since their callback was last called. Or `Timer::clock` to get the clock for the timer and check the time.
* `Time`: The callback will receive the current time of the clock that is being used by the timer
* Nothing: The callback can have no arguments at all

We could also support `Duration` which would provide the time lapsed since the last call to the callback. I'm happy to add that if anyone would find that interesting.

## Idiomatic API

In the original PR there was significant use of `i64` with function names that include `_nanos` to signal to the user that they should interpret the integers as nanoseconds. This is not idiomatic for Rust. We should prefer rigid explicit types like `Duration` and `Time`. This PR updates all rclrs API function arguments and fields to explicitly use `Time` and `Duration`, and not use `i64` anywhere.